### PR TITLE
Added a CreateAccount Page.

### DIFF
--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+function getBaseUrl(): string {
+  // TODO: Implement the function that returns the base URL for the account API.
+  return '';
+}
+axios.defaults.withCredentials = true;
+
+/**
+ * The AccountAPI class is responsible for communicating with the server with
+ * matters concerning accounts and users on MapHub.
+ */
+class AccountAPI {
+  static api = axios.create({
+    baseURL: getBaseUrl(),
+  });
+
+  static async registerUser(username: string, email: string, password: string, passwordConfirm: string) {
+    return this.api.post('/register', {
+      username,
+      email,
+      password,
+      passwordVerify: passwordConfirm,
+    });
+  }
+}
+
+export default AccountAPI;

--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -4,18 +4,34 @@ function getBaseUrl(): string {
   // TODO: Implement the function that returns the base URL for the account API.
   return '';
 }
-axios.defaults.withCredentials = true;
 
 /**
- * The AccountAPI class is responsible for communicating with the server with
- * matters concerning accounts and users on MapHub.
+ * The AccountAPI is responsible for sending and receiving requests from the
+ * server for account login, creation, deletion, and modifications. 
  */
 class AccountAPI {
   static api = axios.create({
     baseURL: getBaseUrl(),
+    withCredentials: true,
   });
 
-  static async registerUser(username: string, email: string, password: string, passwordConfirm: string) {
+  /**
+   * Sends a POST request to the server to create a new account with a username,
+   * email address, password, and password confirmation. Returns a response from
+   * the server.
+   * 
+   * @param username - the new account username
+   * @param email - the new account email address
+   * @param password - the new account password
+   * @param passwordConfirm - the new account password confirmation
+   * @returns the server response
+   */
+  static async registerUser(
+    username: string,
+    email: string,
+    password: string,
+    passwordConfirm: string
+  ) {
     return this.api.post('/register', {
       username,
       email,

--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -1,8 +1,26 @@
 import axios from 'axios';
 
+const SERVER_PORT = 3031
+
 function getBaseUrl(): string {
-  // TODO: Implement the function that returns the base URL for the account API.
-  return '';
+  if (typeof window === "undefined") {
+    return ""
+  }
+  
+
+  // if hostname is localhost, change the port, else prepend with api
+  let baseURL = ""
+  if (window.location.hostname === "localhost") {
+    baseURL = `http://localhost:${SERVER_PORT}`
+  } else {
+    baseURL = `https://api.${window.location.hostname}`
+  }
+  // if pathname has /dev, the url we return also has /dev
+  if (window.location.pathname.startsWith("/dev")) {
+    baseURL += "/dev"
+  }
+  console.log("base url is " + baseURL)
+  return baseURL
 }
 
 /**

--- a/client/src/app/account/create/page.tsx
+++ b/client/src/app/account/create/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Typography } from '@mui/material';
 
 import styles from './ui/createAccountPage.module.css';
+import CreateAccountForm from './ui/components/createAccountForm';
 
 function Page() {
   return (
@@ -16,6 +17,7 @@ function Page() {
         Join MapHub to edit maps in any way you can imagine. Get access to
         liking, commenting, and sharing others' maps.
       </Typography>
+      <CreateAccountForm />
     </div>
   );
 }

--- a/client/src/app/account/create/page.tsx
+++ b/client/src/app/account/create/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { Typography } from '@mui/material';
+
+import styles from './ui/createAccountPage.module.css';
+
+function Page() {
+  return (
+    <div className={styles.container}>
+      <Link className={styles.navLink} href="/">
+        Home
+      </Link>
+      <Typography className={styles.title} variant="h3" align="center">
+        Create an account
+      </Typography>
+      <Typography className={styles.body} variant="body1" align="left">
+        Join MapHub to edit maps in any way you can imagine. Get access to
+        liking, commenting, and sharing others' maps.
+      </Typography>
+    </div>
+  );
+}
+
+export default Page;

--- a/client/src/app/account/create/ui/components/ValidatedTextField.tsx
+++ b/client/src/app/account/create/ui/components/ValidatedTextField.tsx
@@ -1,0 +1,79 @@
+import { TextField } from "@mui/material";
+import { useState, ChangeEventHandler, FocusEventHandler } from "react";
+
+import styles from './validatedTextField.module.css';
+
+interface ValidatedTextFieldProps {
+  id: string,
+  type: string,
+  label: string,
+  value: string,
+  // Set value is a function that sets the input value state of a parent
+  // component.
+  setValue: (value: string) => void,
+  maxLength?: number,
+  error: boolean,
+  // Set value is a function that sets the input error state of a parent
+  // component.
+  validate: () => void,
+  helperText: string,
+};
+
+/*
+ * ValidatedTextField is a component that wraps around the outlined MUI Text
+ * Field. It performs validation when the user finishes typing their input 
+ * (onBlur). Validation is performed on changes to the input each time
+ * afterwards.
+ */
+function ValidatedTextField({
+  id,
+  type,
+  label,
+  value,
+  setValue,
+  maxLength,
+  error,
+  validate,
+  helperText
+}: ValidatedTextFieldProps) {
+  // A boolean state indicating whether or not the component should validate
+  // the input field.
+  const [isValidating, setIsValidating] = useState(false);
+
+  // The change handler controls the input value state, but also validates if
+  // necessary. Furthermore, it enforces the maximum length by disallowing
+  // changes over the limit.
+  const handleChange: ChangeEventHandler = (event) => {
+    const inputValue = (event.target as HTMLInputElement).value;
+    if (maxLength && inputValue.length <= maxLength) {
+      setValue(inputValue);
+      if (isValidating) {
+        validate();
+      }
+    }
+  }
+
+  // The focus handler validates the user input, but also requires that
+  // validation is performed on every change afterwards.
+  const handleBlur: FocusEventHandler = (event) => {
+    setIsValidating(true);
+    validate();
+  }
+
+  return (
+    <TextField
+      className={styles.textField}
+      id={id}
+      type={type}
+      label={label}
+      value={value}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      variant='outlined'
+      error={error}
+      helperText={helperText}
+    />
+  );
+}
+
+export default ValidatedTextField;

--- a/client/src/app/account/create/ui/components/ValidatedTextField.tsx
+++ b/client/src/app/account/create/ui/components/ValidatedTextField.tsx
@@ -45,7 +45,7 @@ function ValidatedTextField({
   // changes over the limit.
   const handleChange: ChangeEventHandler = (event) => {
     const inputValue = (event.target as HTMLInputElement).value;
-    if (maxLength && inputValue.length <= maxLength) {
+    if ((maxLength && inputValue.length <= maxLength) || !maxLength) {
       setValue(inputValue);
       if (isValidating) {
         validate();

--- a/client/src/app/account/create/ui/components/ValidatedTextField.tsx
+++ b/client/src/app/account/create/ui/components/ValidatedTextField.tsx
@@ -3,6 +3,9 @@ import { useState, ChangeEventHandler, FocusEventHandler } from "react";
 
 import styles from './validatedTextField.module.css';
 
+/**
+ * The ValidatedTextFieldProps are the elements that go into a text field.
+ */
 interface ValidatedTextFieldProps {
   id: string,
   type: string,

--- a/client/src/app/account/create/ui/components/createAccountForm.module.css
+++ b/client/src/app/account/create/ui/components/createAccountForm.module.css
@@ -1,0 +1,14 @@
+.container {
+  display: flex;
+  flex-direction: column;
+
+  width: 80%;
+  margin: 4% auto;
+  border-radius: 28px;
+  padding: 32px 0;
+
+  box-shadow:
+    0   1px 2px 0   rgba(0, 0, 0, 30%),
+    0   1px 3px 1px rgba(0, 0, 0, 15%);
+  
+}

--- a/client/src/app/account/create/ui/components/createAccountForm.module.css
+++ b/client/src/app/account/create/ui/components/createAccountForm.module.css
@@ -5,10 +5,33 @@
   width: 80%;
   margin: 4% auto;
   border-radius: 28px;
-  padding: 32px 0;
+  padding: 32px 16%;
 
   box-shadow:
     0   1px 2px 0   rgba(0, 0, 0, 30%),
     0   1px 3px 1px rgba(0, 0, 0, 15%);
+}
+
+.confirmButton {
+  align-self: flex-end;
+
+  width: 40%;
+  height: 40px;
+  margin-top: 32px;
+  border-radius: 100000px;
+
+  background-color: #0081A7;
+  box-shadow: none;
+  transition:
+    background-color 250ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1);
   
+  text-transform: none;
+}
+
+.confirmButton:hover {
+  background-color: #138BAE;
+  box-shadow:
+    0   1px 2px 0   rgba(0, 0, 0, 30%),
+    0   1px 3px 1px rgba(0, 0, 0, 15%);
 }

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -57,7 +57,7 @@ function createAccountReducer(
   action: CreateAccountAction
 ): CreateAccountState {
   switch (action.type) {
-    case CreateAccountActionType.updateUsername:
+    case CreateAccountActionType.updateUsername: {
       return {
         ...state,
         username: {
@@ -65,7 +65,8 @@ function createAccountReducer(
           value: action.value,
         },
       };
-    case CreateAccountActionType.validateUsername:
+    }
+    case CreateAccountActionType.validateUsername: {
       // Checks if the username is well-formed. A well-formed username must
       // include alphanumeric characters, underscores, or dots such that the 
       // last character is not a dot. The username must also be between 3 to 16
@@ -84,7 +85,8 @@ function createAccountReducer(
         ...state,
         username,
       };
-    case CreateAccountActionType.updateEmail:
+    }
+    case CreateAccountActionType.updateEmail: {
       return {
         ...state,
         email: {
@@ -92,7 +94,8 @@ function createAccountReducer(
           value: action.value,
         },
       };
-    case CreateAccountActionType.validateEmail:
+    }
+    case CreateAccountActionType.validateEmail: {
       // Checks if the email address is well-formed. An email address is
       // well-formed if it starts with a set of alphanumeric characters,
       // underscores, and dots, followed by an @ symbol, followed by a domain
@@ -111,7 +114,8 @@ function createAccountReducer(
         ...state,
         email,
       };
-    case CreateAccountActionType.updatePassword:
+    }
+    case CreateAccountActionType.updatePassword: {
       return {
         ...state,
         password: {
@@ -119,7 +123,8 @@ function createAccountReducer(
           value: action.value,
         },
       };
-    case CreateAccountActionType.validatePassword:
+    }
+    case CreateAccountActionType.validatePassword: {
       // Checks if the password is well-formed. A password is well-formed if it
       // is a set of characters such that it is longer than 8 characters and 
       // contains one uppercase letter, one lowercase letter, and one digit.
@@ -136,8 +141,33 @@ function createAccountReducer(
         ...state,
         password,
       };
-    default:
+    }
+    case CreateAccountActionType.updatePasswordConfirm: {
+      return {
+        ...state,
+        passwordConfirm: {
+          ...state.passwordConfirm,
+          value: action.value,
+        },
+      };
+    }
+    case CreateAccountActionType.validatePasswordConfirm: {
+      const { password, passwordConfirm } = state;
+      if (password.value !== passwordConfirm.value) {
+        passwordConfirm.error = true;
+        passwordConfirm.errorText = 'Please reconfirm the password.'
+      } else {
+        passwordConfirm.error = false;
+        passwordConfirm.errorText = '';
+      }
+      return {
+        ...state,
+        passwordConfirm,
+      }
+    }
+    default: {
       return state;
+    }
   }
 }
 
@@ -208,6 +238,20 @@ function CreateAccountForm() {
     });
   }
 
+  const setPasswordConfirm = (value: string) => {
+    createAccountDispatch({
+      type: CreateAccountActionType.updatePasswordConfirm,
+      value,
+    });
+  }
+
+  const validatePasswordConfirm = () => {
+    createAccountDispatch({
+      type: CreateAccountActionType.validatePasswordConfirm,
+    });
+  };
+
+
   return (
     <div className={styles.container}>
       <ValidatedTextField
@@ -240,6 +284,16 @@ function CreateAccountForm() {
         error={createAccountState.password.error}
         validate={validatePassword}
         helperText={createAccountState.password.errorText}
+      />
+      <ValidatedTextField
+        id="password-confirm"
+        type="password"
+        label="Confirm Password"
+        value={createAccountState.passwordConfirm.value}
+        setValue={setPasswordConfirm}
+        error={createAccountState.passwordConfirm.error}
+        validate={validatePasswordConfirm}
+        helperText={createAccountState.passwordConfirm.errorText}
       />
     </div>
   );

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -215,7 +215,12 @@ function createAccountReducer(
   }
 }
 
-
+/**
+ * The CreateAccountForm renders a frontend form with the following text fields:
+ * username, email address, password, and confirm password. The form also 
+ * includes a button for submission. The state of the form and its verification
+ * is handled by the createAccountReducer.
+ */
 function CreateAccountForm() {
   const [ createAccountState, createAccountDispatch ] = useReducer(
     createAccountReducer,
@@ -300,7 +305,6 @@ function CreateAccountForm() {
       type: CreateAccountActionType.validate,
     });
   }
-
 
   return (
     <div className={styles.container}>

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -72,7 +72,7 @@ function createAccountReducer(
       // characters.
       // TODO: Implement unique username checking.
       const { username } = state;
-      if (!/^[\w\.]{2,15}[\w]$/.test(state.username.value)) {
+      if (!/^[\w\.]{2,15}[\w]$/.test(username.value)) {
         username.error = true;
         username.errorText = 'Please enter a valid username between 3-16 ' + 
           'alphanumeric, underscore, or dot characters.';
@@ -84,6 +84,33 @@ function createAccountReducer(
         ...state,
         username,
       };
+    case CreateAccountActionType.updateEmail:
+      return {
+        ...state,
+        email: {
+          ...state.email,
+          value: action.value,
+        },
+      };
+    case CreateAccountActionType.validateEmail:
+      // Checks if the email address is well-formed. An email address is
+      // well-formed if it starts with a set of alphanumeric characters,
+      // underscores, and dots, followed by an @ symbol, followed by a domain
+      // name (set of alphanumeric characters, underscores, and dots such that
+      // it ends with a dot), and followed by a top-level domain name (a set of
+      // alphanumeric characters and underscores of length 2-4). 
+      const { email } = state;
+      if (!/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/.test(email.value)) {
+        email.error = true;
+        email.errorText = 'Please enter a valid email address.'
+      } else {
+        email.error = false;
+        email.errorText = '';
+      }
+      return {
+        ...state,
+        email,
+      }
     default:
       return state;
   }
@@ -130,6 +157,19 @@ function CreateAccountForm() {
     });
   };
 
+  const setEmail = (value: string) => {
+    createAccountDispatch({
+      type: CreateAccountActionType.updateEmail,
+      value,
+    });
+  };
+
+  const validateEmail = () => {
+    createAccountDispatch({
+      type: CreateAccountActionType.validateEmail,
+    });
+  };
+
   return (
     <div className={styles.container}>
       <ValidatedTextField
@@ -143,8 +183,18 @@ function CreateAccountForm() {
         validate={validateUsername}
         helperText={createAccountState.username.errorText}
       />
+      <ValidatedTextField
+        id="email"
+        type="email"
+        label="Email Address"
+        value={createAccountState.email.value}
+        setValue={setEmail}
+        error={createAccountState.email.error}
+        validate={validateEmail}
+        helperText={createAccountState.email.errorText}
+      />
     </div>
-  )
+  );
 }
 
 export default CreateAccountForm;

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useReducer } from 'react';
+
+import ValidatedTextField from './ValidatedTextField';
+
+import styles from './createAccountForm.module.css';
+
+/**
+ * The CreateAccountState is an object filled with states of text field 
+ * parameters. Each text field parameter holds the following:
+ *     * value - the actual text value of the input text field,
+ *     * error - a boolean indicating whether or not the input is valid, and
+ *     * errorText - an error message indicating why the value is not valid.
+ */
+interface CreateAccountFieldState {
+  value: string,
+  error: boolean,
+  errorText: string,
+};
+interface CreateAccountState {
+  username: CreateAccountFieldState,
+  email: CreateAccountFieldState,
+  password: CreateAccountFieldState,
+  passwordConfirm: CreateAccountFieldState,
+};
+
+/**
+ * CreateAccountActionType represents the type of action the reducer must
+ * perform. CreateAccountAction represents the type of action and the values
+ * that needs to be passed to the reducer to perform the action. 
+ */
+enum CreateAccountActionType {
+  updateUsername = 'updateUsername',
+  validateUsername = 'validateUsername',
+  updateEmail = 'updateEmail',
+  validateEmail = 'validateEmail',
+  updatePassword = 'updatePassword',
+  validatePassword = 'validatePassword',
+  updatePasswordConfirm = 'updatePasswordConfirm',
+  validatePasswordConfirm = 'validatePasswordConfirm',
+};
+interface CreateAccountAction {
+  type: CreateAccountActionType,
+  value?: any,
+}
+
+/**
+ * The createAccountReducer function takes the current state along with an
+ * action to perform on the state. It returns a new state with the action
+ * performed. The actions include: updating the value of text fields and 
+ * validating the text field values. Validation checks the current value in the
+ * state and modifies the error and errorText states for the text field.
+ */
+function createAccountReducer(
+  state: CreateAccountState,
+  action: CreateAccountAction
+): CreateAccountState {
+  switch (action.type) {
+    case CreateAccountActionType.updateUsername:
+      return {
+        ...state,
+        username: {
+          ...state.username,
+          value: action.value,
+        },
+      };
+    case CreateAccountActionType.validateUsername:
+      // Checks if the username is well-formed. A well-formed username must
+      // include alphanumeric characters, underscores, or dots such that the 
+      // last character is not a dot. The username must also be between 3 to 16
+      // characters.
+      // TODO: Implement unique username checking.
+      const { username } = state;
+      if (!/^[\w\.]{2,15}[\w]$/.test(state.username.value)) {
+        username.error = true;
+        username.errorText = 'Please enter a valid username between 3-16 ' + 
+          'alphanumeric, underscore, or dot characters.';
+      } else {
+        username.error = false;
+        username.errorText = '';
+      }
+      return {
+        ...state,
+        username,
+      };
+    default:
+      return state;
+  }
+}
+
+
+function CreateAccountForm() {
+  const [ createAccountState, createAccountDispatch ] = useReducer(
+    createAccountReducer,
+    {
+      username: {
+        value: '',
+        error: false,
+        errorText: '',
+      },
+      email: {
+        value: '',
+        error: false,
+        errorText: '',
+      },
+      password: {
+        value: '',
+        error: false,
+        errorText: '',
+      },
+      passwordConfirm: {
+        value: '',
+        error: false,
+        errorText: '',
+      },
+    },
+  );
+
+  const setUsername = (value: string) => {
+    createAccountDispatch({
+      type: CreateAccountActionType.updateUsername,
+      value,
+    });
+  };
+
+  const validateUsername = () => {
+    createAccountDispatch({
+      type: CreateAccountActionType.validateUsername,
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <ValidatedTextField
+        id="username"
+        type="text"
+        label="Username"
+        value={createAccountState.username.value}
+        setValue={setUsername}
+        maxLength={16}
+        error={createAccountState.username.error}
+        validate={validateUsername}
+        helperText={createAccountState.username.errorText}
+      />
+    </div>
+  )
+}
+
+export default CreateAccountForm;

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -110,7 +110,32 @@ function createAccountReducer(
       return {
         ...state,
         email,
+      };
+    case CreateAccountActionType.updatePassword:
+      return {
+        ...state,
+        password: {
+          ...state.password,
+          value: action.value,
+        },
+      };
+    case CreateAccountActionType.validatePassword:
+      // Checks if the password is well-formed. A password is well-formed if it
+      // is a set of characters such that it is longer than 8 characters and 
+      // contains one uppercase letter, one lowercase letter, and one digit.
+      const { password } = state;
+      if (!/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/.test(password.value)) {
+        password.error = true;
+        password.errorText = 'Please enter a password with at least eight ' +
+          'characters with one uppercase, one lowercase, and one digit';
+      } else {
+        password.error = false;
+        password.errorText = '';
       }
+      return {
+        ...state,
+        password,
+      };
     default:
       return state;
   }
@@ -170,6 +195,19 @@ function CreateAccountForm() {
     });
   };
 
+  const setPassword = (value: string) => {
+    createAccountDispatch({
+      type: CreateAccountActionType.updatePassword,
+      value,
+    });
+  };
+
+  const validatePassword = () => {
+    createAccountDispatch({
+      type: CreateAccountActionType.validatePassword,
+    });
+  }
+
   return (
     <div className={styles.container}>
       <ValidatedTextField
@@ -192,6 +230,16 @@ function CreateAccountForm() {
         error={createAccountState.email.error}
         validate={validateEmail}
         helperText={createAccountState.email.errorText}
+      />
+      <ValidatedTextField
+        id="password"
+        type="password"
+        label="Password"
+        value={createAccountState.password.value}
+        setValue={setPassword}
+        error={createAccountState.password.error}
+        validate={validatePassword}
+        helperText={createAccountState.password.errorText}
       />
     </div>
   );

--- a/client/src/app/account/create/ui/components/validatedTextField.module.css
+++ b/client/src/app/account/create/ui/components/validatedTextField.module.css
@@ -1,4 +1,4 @@
 .textField {
-  width: 60%;
+  width: 100%;
   margin: 12px auto;
 }

--- a/client/src/app/account/create/ui/components/validatedTextField.module.css
+++ b/client/src/app/account/create/ui/components/validatedTextField.module.css
@@ -1,0 +1,4 @@
+.textField {
+  width: 60%;
+  margin: 12px auto;
+}

--- a/client/src/app/account/create/ui/createAccountPage.module.css
+++ b/client/src/app/account/create/ui/createAccountPage.module.css
@@ -1,0 +1,28 @@
+.container {
+  width: 50%;
+  min-height: 100%;
+
+  margin: 0 auto;
+  border: none;
+  padding: 50px 0;
+}
+
+.title {
+  margin: 5% 0;
+}
+
+.body {
+  display: block;
+  width: 60%;
+  margin: 0 auto;
+}
+
+.navLink {
+  color: #0081A7;
+  text-decoration: underline;
+  transition: color 250ms cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+.navLink:hover {
+  color: #004D64;
+}

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -17,11 +17,6 @@
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  width: 100%;
+  height: 100%;
 }

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
+import styles from './ui/homePage.module.css';
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
@@ -10,20 +12,17 @@ export default function Home() {
         MAPHUB - the Porn Hub Alternative for Maps
       </Typography>
 
-      <Link href="/about">
-        <Button
-          variant="contained"
-          style={{
-            width: '100%',
-            fontSize: '3rem',
-            color: 'white',
-            backgroundColor: 'black',
-            borderRadius: '25px',
-          }}
-        >
-          About
+      
+        <Button className={styles.navButton} variant="contained">
+          <Link href="/about">
+            About
+          </Link>
         </Button>
-      </Link>
+      <Button className={styles.navButton} variant="contained">
+        <Link href="/account/create">
+          Join Now
+        </Link>
+      </Button>
     </main>
   );
 }

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -11,13 +11,11 @@ export default function Home() {
       <Typography style={{ fontSize: '3rem' }}>
         MAPHUB - the Porn Hub Alternative for Maps
       </Typography>
-
-      
-        <Button className={styles.navButton} variant="contained">
-          <Link href="/about">
-            About
-          </Link>
-        </Button>
+      <Button className={styles.navButton} variant="contained">
+        <Link href="/about">
+          About
+        </Link>
+      </Button>
       <Button className={styles.navButton} variant="contained">
         <Link href="/account/create">
           Join Now

--- a/client/src/app/ui/homePage.module.css
+++ b/client/src/app/ui/homePage.module.css
@@ -1,0 +1,4 @@
+.navButton {
+  background-color: #0081A7;
+  color: #F2FBFB;
+}


### PR DESCRIPTION
The **CreateAccoun**t page (`/account/create`) renders a form for the user to fill out their username, email address, password, and to confirm their password. The form also contains a button to submit the creation request to the backend server.
### Features
- Text fields offer both real-time and late verification. Verification is done when the user finishes filling out a text field for the first time. Verification is checked on every change to the text field value afterwards. 
  - Usernames must be between 3 and 16 characters long. They can be any combination of alphanumeric characters, underscores, dots, and digits. However, they cannot end with a dot.
  - Email addresses must contain a local-part, followed by the `@` symbol, followed by a domain name, followed by the top-level domain.
  - Passwords must be at least 8 characters long. They can be any combination of characters, but must contain at least one uppercase letter, one lowercase letter, and one digit.
- A `createAccountReducer` handles the logic behind verification and manages the state of the form's text fields.
  - `value` is the actual value of the input in the text field,
  - `error`  indicates if the value passes verification, and
  - `errorText` is some helper message that indicates why there is an error.
### To Dos
- Implement a method of checking whether a username is unique on the server as part of the verification for usernames.
- Use the response from sending the request for creating an account to the server by navigating to another page or indicating to the user it succeeded.
- Implement a function to determine the base URL of the backend server as part of the `AccountAPI` requester class.