### PR TITLE
Added configuration for Cypress component tests.

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -9,6 +9,7 @@
 cypress.env.json
 # testing
 /coverage
+/cypress/screenshots
 
 # next.js
 /.next/

--- a/client/cypress.config.ts
+++ b/client/cypress.config.ts
@@ -25,5 +25,7 @@ export default defineConfig({
       framework: 'next',
       bundler: 'webpack',
     },
+    supportFile: 'cypress/support/component.ts',
+    specPattern: 'cypress/components/**/*.cy.{js,jsx,ts,tsx}',
   },
 });

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,9 @@
     "test": "jest --watch",
     "test:ci": "jest --ci",
     "cypress": "cypress open",
-    "cypress:run": "cypress run 'cypress/e2e/*.cy.ts'"
+    "cypress:run": "cypress run --e2e && cypress run --component",
+    "cypress:e2e": "cypress run --e2e",
+    "cypress:component": "cypress run --component"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
### Features
- Added a new configuration for Cypress component tests which looks for spec files in `/cypress/components/`.
- Modifies the `package.json` scripts to run both component tests and end-to-end tests when running `npm run cypress:run`.
  -  `npm run cypress:e2e` only executes end-to-end tests.
  -  `npm run cypress:component` only executes component tests.
- Added Git ignores for `/cypress/screenshots`.