### PR TITLE
Created account verification.

### DIFF
--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -103,6 +103,10 @@ class AccountAPI {
   static async postUsername(username: string) {
     return this.api.post('/auth/username', { username });
   }
+
+  static async getVerify() {
+    return this.api.get('/auth/verify');
+  }
 }
 
 export default AccountAPI;

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -54,12 +54,14 @@ function authManager() {
     }
   };
 
-  const verifyUser = async (tokenInQ: jwt.JwtPayload) => {
+  const verifyUser = async (request: Request) => {
     try {
-      console.log('RETURN seom decoded token');
-      // return decodedToken?.userId || null;
-      //TODO NENED TO MAKE THIS ACTUALL FIND A USER AND VERIFIY IT;
-    } catch (err) {
+      const token = request.cookies.token;
+      if (!token) {
+        return null;
+      }
+      return jwt.verify(token, jwtSecret) as jwt.JwtPayload;
+    } catch (error) {
       return null;
     }
   };

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -175,6 +175,33 @@ export const getExists = async (request: Request, response: Response) => {
   }
 };
 
+export const getVerify = async (request: Request, response: Response) => {
+  const notLoggedInBody = {
+    isLoggedIn: false,
+    user: null,
+  };
+  try {
+    const tokenPayload = await auth.verifyUser(request);
+    if (!tokenPayload) {
+      return response.status(200).json(notLoggedInBody);
+    }
+    const user = await User.findById(tokenPayload.verifiedId);
+    if (!user) {
+      return response.status(200).json(notLoggedInBody);
+    }
+    return response.status(200).json({
+      isLoggedIn: true,
+      user: {
+        id: user._id,
+        username: user.username,
+        profilePic: Buffer.from(user.profilePic).toString('base64'),
+      },
+    });
+  } catch (error) {
+    return response.status(200).json(notLoggedInBody);
+  }
+};
+
 export const getProfilePic = async (request: Request, response: Response) => {
   try {
     const { id } = request.body;

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -176,6 +176,11 @@ export const getExists = async (request: Request, response: Response) => {
 };
 
 export const getVerify = async (request: Request, response: Response) => {
+  const headers = {
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    Pragma: 'no-cache',
+    Expires: '0',
+  };
   const notLoggedInBody = {
     isLoggedIn: false,
     user: null,
@@ -183,22 +188,25 @@ export const getVerify = async (request: Request, response: Response) => {
   try {
     const tokenPayload = await auth.verifyUser(request);
     if (!tokenPayload) {
-      return response.status(200).json(notLoggedInBody);
+      return response.status(200).set(headers).json(notLoggedInBody);
     }
-    const user = await User.findById(tokenPayload.verifiedId);
+    const user = await User.findById(tokenPayload.userId);
     if (!user) {
-      return response.status(200).json(notLoggedInBody);
+      return response.status(200).set(headers).json(notLoggedInBody);
     }
-    return response.status(200).json({
-      isLoggedIn: true,
-      user: {
-        id: user._id,
-        username: user.username,
-        profilePic: Buffer.from(user.profilePic).toString('base64'),
-      },
-    });
+    return response
+      .status(200)
+      .set(headers)
+      .json({
+        isLoggedIn: true,
+        user: {
+          id: user._id,
+          username: user.username,
+          profilePic: Buffer.from(user.profilePic).toString('base64'),
+        },
+      });
   } catch (error) {
-    return response.status(200).json(notLoggedInBody);
+    return response.status(200).set(headers).json(notLoggedInBody);
   }
 };
 

--- a/server/routes/auth-router.ts
+++ b/server/routes/auth-router.ts
@@ -8,6 +8,7 @@ router.post('/register', AuthController.registerUser);
 router.get('/users', AuthController.getAllUsers);
 router.get('/exists', AuthController.getExists);
 router.get('/profile-picture', AuthController.getProfilePic);
+router.get('/verify', AuthController.getVerify);
 router.post('/username', auth.verify, AuthController.postUsername);
 router.post('/login', AuthController.loginUser);
 router.post('/logout', AuthController.logoutUser);

--- a/server/tests/user.test.ts
+++ b/server/tests/user.test.ts
@@ -326,7 +326,7 @@ describe('GET /auth/verify ', () => {
 
   it('should send a login response if cookies are correct.', async () => {
     (auth.verifyUser as jest.Mock).mockResolvedValue({
-      verifiedId: mockUser._id,
+      userId: mockUser._id,
     });
     (userModel.findById as jest.Mock).mockResolvedValue(mockUser);
 
@@ -345,7 +345,7 @@ describe('GET /auth/verify ', () => {
 
   it('should send a not logged in response if cookies include an invalid user ID.', async () => {
     (auth.verifyUser as jest.Mock).mockResolvedValue({
-      verifiedId: anotherMockUser._id,
+      userId: anotherMockUser._id,
     });
     (userModel.findById as jest.Mock).mockResolvedValue(null);
 


### PR DESCRIPTION
Fixed the issue where the `AuthProvider` signs a user out on refresh.

### Features
- Created a `GET` `/auth/verify` endpoint that checks the request cookie for a `userId`, verifies login status, and sends a response with the `user` details.
  - Implements the `auth.verifyUser(request: Request)` method, which accepts an Express request and returns the decrypted JSON web token payload.
- Modified the `AuthProvider` to check for login status on the first render with the `useEffect()` hook.
  -  Added a `AccountAPI.verify()` method that returns the endpoint's response.
  - Created a new `AuthActionType.VERIFY` to perform verification by replacing the `value.state.isLoggedIn` and `value.state.user`.