### PR TITLE
Fixed Settings and EditUsername Pages.

### DIFF
--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -103,6 +103,10 @@ class AccountAPI {
   static async postUsername(username: string) {
     return this.api.post('/auth/username', { username });
   }
+
+  static async getVerify() {
+    return this.api.get('/auth/verify');
+  }
 }
 
 export default AccountAPI;

--- a/client/src/app/account/create/ui/components/createAccountForm.tsx
+++ b/client/src/app/account/create/ui/components/createAccountForm.tsx
@@ -323,7 +323,7 @@ function CreateAccountForm() {
           type: AuthActions.REGISTER_SUCCESS,
           payload: {
             user: {
-              id: result.data.user._id,
+              id: result.data.user.id,
               username: result.data.user.username,
               profilePic: URL.createObjectURL(
                 base64StringToBlob(result.data.user.profilePic),
@@ -364,7 +364,7 @@ function CreateAccountForm() {
     if (successSnackbarOpen) {
       // If either snackbar is open, initiate the redirect after a delay
       const timer = setTimeout(() => {
-        router.replace('/account/sign-in');
+        router.replace('/account/dashboard');
       }, 1000); // Adjust the delay as needed
 
       // Cleanup function to clear the timer if the component unmounts
@@ -453,7 +453,7 @@ function CreateAccountForm() {
           onClose={handleSnackbarClose}
           severity="success"
         >
-          Account created successfully! Redirecting to login...
+          Account created successfully! Redirecting to dashboard...
         </Alert>
       </Snackbar>
     </div>

--- a/client/src/app/account/settings/components/settingsPane.tsx
+++ b/client/src/app/account/settings/components/settingsPane.tsx
@@ -8,7 +8,10 @@ function SettingsPane({
   ...props
 }: HTMLAttributes<HTMLElement>) {
   return (
-    <Box className={`${styles['settings__pane']} ${className}`} {...props}>
+    <Box
+      className={`${styles['settings__pane']} ${className ? className : ''}`}
+      {...props}
+    >
       {children}
     </Box>
   );

--- a/client/src/app/account/settings/page.tsx
+++ b/client/src/app/account/settings/page.tsx
@@ -22,10 +22,10 @@ function Settings() {
   const router = useRouter();
 
   useEffect(() => {
-    if (!auth.state.isLoggedIn) {
+    if (auth.state.isLoggedIn === false) {
       router.replace('/account/sign-in');
     }
-  }, []);
+  }, [auth.state.isLoggedIn]);
 
   return (
     <SettingsMain id="settings" className={styles['settings__box']}>

--- a/client/src/app/account/settings/styles/settingsHead.module.scss
+++ b/client/src/app/account/settings/styles/settingsHead.module.scss
@@ -1,3 +1,8 @@
 .settings__head {
   grid-area: head;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  height: calc(100% - 120px);
 }

--- a/client/src/app/account/settings/styles/settingsMain.module.scss
+++ b/client/src/app/account/settings/styles/settingsMain.module.scss
@@ -8,7 +8,7 @@
     ". head pane .";
   align-items: center;
 
-  height: calc(100% - 120px);
+  min-height: calc(100% - 120px);
 
   color: colors.$on-surface;
 }

--- a/client/src/app/account/settings/styles/settingsPane.module.scss
+++ b/client/src/app/account/settings/styles/settingsPane.module.scss
@@ -10,11 +10,9 @@
   flex-direction: column;
   gap: shape.$extra-large;
 
-  width: calc(100% - 48px);
-  height: 80%;
+  width: calc(100% - 56px);
+  min-height: 80%;
   padding: shape.$extra-large;
 
   background-color: colors.$surface-container;
-
-  overflow: scroll;
 }

--- a/client/src/app/account/settings/username/page.tsx
+++ b/client/src/app/account/settings/username/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEventHandler, useContext, useState } from 'react';
+import { MouseEventHandler, useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { AuthActions, AuthContext } from '../../../../context/AuthProvider';
@@ -21,6 +21,12 @@ function EditUsername() {
   const [newUsername, setNewUsername] = useState('');
   const [newUsernameError, setNewUsernameError] = useState(false);
   const [newUsernameHelperText, setNewUsernameHelperText] = useState('');
+
+  useEffect(() => {
+    if (auth.state.isLoggedIn === false) {
+      router.replace('/account/sign-in');
+    }
+  }, [auth.state.isLoggedIn]);
 
   const validate = async (value: string) => {
     if (!/^[\w.]{2,15}\w$/.test(value)) {
@@ -82,7 +88,7 @@ function EditUsername() {
           <SettingsReadTextField
             id="current-username"
             label="Current Username"
-            value={auth.state.user?.username}
+            value={auth.state.user?.username ? auth.state.user.username : ''}
           />
           <SettingsTextField
             id="new-username"

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -5,7 +5,7 @@ import React, { Dispatch, createContext, useEffect, useReducer } from 'react';
 import AccountAPI from '../api/AccountAPI';
 
 export interface IAuthState {
-  isLoggedIn: boolean;
+  isLoggedIn?: boolean;
   user: {
     id: string;
     username: string;
@@ -15,7 +15,6 @@ export interface IAuthState {
 }
 
 const initialState: IAuthState = {
-  isLoggedIn: false,
   user: null,
   error: '',
 };
@@ -148,9 +147,9 @@ export class AuthHelpers {
           type: AuthActions.REGISTER_SUCCESS,
           payload: {
             user: {
-              id: result.data._id,
+              id: result.data.user.id,
               username: user.username,
-              profilePic: result.data.profilePic,
+              profilePic: result.data.user.profilePic,
             },
           },
         });

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -54,12 +54,14 @@ function authManager() {
     }
   };
 
-  const verifyUser = async (tokenInQ: jwt.JwtPayload) => {
+  const verifyUser = async (request: Request) => {
     try {
-      console.log('RETURN seom decoded token');
-      // return decodedToken?.userId || null;
-      //TODO NENED TO MAKE THIS ACTUALL FIND A USER AND VERIFIY IT;
-    } catch (err) {
+      const token = request.cookies.token;
+      if (!token) {
+        return null;
+      }
+      return jwt.verify(token, jwtSecret) as jwt.JwtPayload;
+    } catch (error) {
       return null;
     }
   };

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -175,6 +175,33 @@ export const getExists = async (request: Request, response: Response) => {
   }
 };
 
+export const getVerify = async (request: Request, response: Response) => {
+  const notLoggedInBody = {
+    isLoggedIn: false,
+    user: null,
+  };
+  try {
+    const tokenPayload = await auth.verifyUser(request);
+    if (!tokenPayload) {
+      return response.status(200).json(notLoggedInBody);
+    }
+    const user = await User.findById(tokenPayload.verifiedId);
+    if (!user) {
+      return response.status(200).json(notLoggedInBody);
+    }
+    return response.status(200).json({
+      isLoggedIn: true,
+      user: {
+        id: user._id,
+        username: user.username,
+        profilePic: Buffer.from(user.profilePic).toString('base64'),
+      },
+    });
+  } catch (error) {
+    return response.status(200).json(notLoggedInBody);
+  }
+};
+
 export const getProfilePic = async (request: Request, response: Response) => {
   try {
     const { id } = request.body;

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -176,6 +176,11 @@ export const getExists = async (request: Request, response: Response) => {
 };
 
 export const getVerify = async (request: Request, response: Response) => {
+  const headers = {
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    Pragma: 'no-cache',
+    Expires: '0',
+  };
   const notLoggedInBody = {
     isLoggedIn: false,
     user: null,
@@ -183,22 +188,25 @@ export const getVerify = async (request: Request, response: Response) => {
   try {
     const tokenPayload = await auth.verifyUser(request);
     if (!tokenPayload) {
-      return response.status(200).json(notLoggedInBody);
+      return response.status(200).set(headers).json(notLoggedInBody);
     }
-    const user = await User.findById(tokenPayload.verifiedId);
+    const user = await User.findById(tokenPayload.userId);
     if (!user) {
-      return response.status(200).json(notLoggedInBody);
+      return response.status(200).set(headers).json(notLoggedInBody);
     }
-    return response.status(200).json({
-      isLoggedIn: true,
-      user: {
-        id: user._id,
-        username: user.username,
-        profilePic: Buffer.from(user.profilePic).toString('base64'),
-      },
-    });
+    return response
+      .status(200)
+      .set(headers)
+      .json({
+        isLoggedIn: true,
+        user: {
+          id: user._id,
+          username: user.username,
+          profilePic: Buffer.from(user.profilePic).toString('base64'),
+        },
+      });
   } catch (error) {
-    return response.status(200).json(notLoggedInBody);
+    return response.status(200).set(headers).json(notLoggedInBody);
   }
 };
 

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -69,14 +69,22 @@ export const registerUser = async (req: Request, res: Response) => {
     });
     const savedUser = await newUser.save();
     console.log('New user saved: ' + savedUser._id);
-    res.status(200).json({
-      success: true,
-      user: {
-        id: savedUser._id,
-        username: savedUser.username,
-        profilePic: Buffer.from(savedUser.profilePic).toString('base64'),
-      },
-    });
+    const token = auth.signToken(savedUser._id.toString());
+    res
+      .status(200)
+      .cookie('token', token, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+      })
+      .json({
+        success: true,
+        user: {
+          id: savedUser._id,
+          username: savedUser.username,
+          profilePic: Buffer.from(savedUser.profilePic).toString('base64'),
+        },
+      });
   } catch (err: any) {
     if (err.code === 11000) {
       console.log(err);

--- a/server/routes/auth-router.ts
+++ b/server/routes/auth-router.ts
@@ -8,6 +8,7 @@ router.post('/register', AuthController.registerUser);
 router.get('/users', AuthController.getAllUsers);
 router.get('/exists', AuthController.getExists);
 router.get('/profile-picture', AuthController.getProfilePic);
+router.get('/verify', AuthController.getVerify);
 router.post('/username', auth.verify, AuthController.postUsername);
 router.post('/login', AuthController.loginUser);
 router.post('/logout', AuthController.logoutUser);

--- a/server/tests/user.test.ts
+++ b/server/tests/user.test.ts
@@ -326,7 +326,7 @@ describe('GET /auth/verify ', () => {
 
   it('should send a login response if cookies are correct.', async () => {
     (auth.verifyUser as jest.Mock).mockResolvedValue({
-      verifiedId: mockUser._id,
+      userId: mockUser._id,
     });
     (userModel.findById as jest.Mock).mockResolvedValue(mockUser);
 
@@ -345,7 +345,7 @@ describe('GET /auth/verify ', () => {
 
   it('should send a not logged in response if cookies include an invalid user ID.', async () => {
     (auth.verifyUser as jest.Mock).mockResolvedValue({
-      verifiedId: anotherMockUser._id,
+      userId: anotherMockUser._id,
     });
     (userModel.findById as jest.Mock).mockResolvedValue(null);
 


### PR DESCRIPTION
Fixed `Settings` and `EditUsername` page to only render if the user is logged in.
### Features
- Modified the `AuthState` such that the `isLoggedIn` field is optional. When it is undefined, it indicates that the `AuthProvider` has not verified the logged in status of the user.
- Changed the registration page flow so when a user successfully registers, they are redirected to the dashboard page.
  - The `POST` `/auth/register` success response now includes cookies with the encrypted user ID.
- The settings and edit username page redirects the user to the sign in page if they are not logged in.
- Adjusted the overflow and sizing styles for the Settings components to fit the grid and scroll properly on overflow.