### PR TITLE
Added password editing.

### DIFF
--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -110,10 +110,22 @@ class AccountAPI {
 
   /**
    * Makes an API call to modify the user's profile picture.
-   * @param profilePic - a base-64 string in WEBP format.
+   * @param profilePic - a base-64 string in PNG, JPG, or GIF format.
    */
   static async putProfilePic(profilePic: string) {
     return this.api.put('/auth/profile-pic', { profilePic });
+  }
+
+  static async putPassword(
+    currentPassword: string,
+    newPassword: string,
+    newPasswordConfirm: string,
+  ) {
+    return this.api.put('/auth/profile-pic', {
+      currentPassword,
+      newPassword,
+      newPasswordConfirm,
+    });
   }
 
   static async getVerify() {

--- a/client/src/api/AccountAPI.ts
+++ b/client/src/api/AccountAPI.ts
@@ -121,7 +121,7 @@ class AccountAPI {
     newPassword: string,
     newPasswordConfirm: string,
   ) {
-    return this.api.put('/auth/profile-pic', {
+    return this.api.put('/auth/password', {
       currentPassword,
       newPassword,
       newPasswordConfirm,

--- a/client/src/app/account/settings/password/page.tsx
+++ b/client/src/app/account/settings/password/page.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { isAxiosError } from 'axios';
+import { useContext, useEffect, useReducer } from 'react';
+import { useRouter } from 'next/navigation';
+
+import AccountAPI from 'api/AccountAPI';
+import { AuthActions, AuthContext } from 'context/AuthProvider';
+import {
+  NotificationsActionType,
+  NotificationsContext,
+} from 'context/notificationsProvider';
+import SettingsMain from '../components/settingsMain';
+import SettingsHead from '../components/settingsHead';
+import SettingsPane from '../components/settingsPane';
+import SettingsSection from '../components/settingsSection';
+import SettingsTextField from '../components/settingsTextField';
+import SettingsButton from '../components/settingsButton';
+
+import styles from './styles/editPassword.module.scss';
+
+interface EditPasswordInput {
+  value: string;
+  error: boolean;
+  helperText: string;
+}
+interface EditPasswordState {
+  currentPassword: EditPasswordInput;
+  newPassword: EditPasswordInput;
+  newPasswordConfirm: EditPasswordInput;
+}
+
+enum EditPasswordActionType {
+  updateCurrentPassword = 'updateCurrentPassword',
+  validateCurrentPassword = 'validateCurrentPassword',
+  invalidateCurrentPassword = 'invalidateCurrentPassword',
+  updateNewPassword = 'updateNewPassword',
+  validateNewPassword = 'validateNewPassword',
+  updateNewPasswordConfirm = 'updateNewPasswordConfirm',
+  validateNewPasswordConfirm = 'validateNewPasswordConfirm',
+  validateAll = 'validateAll',
+}
+
+interface EditPasswordAction {
+  type: EditPasswordActionType;
+  value?: any;
+}
+
+function EditPassword() {
+  const editPasswordReducer = (
+    state: EditPasswordState,
+    action: EditPasswordAction,
+  ): EditPasswordState => {
+    switch (action.type) {
+      case EditPasswordActionType.updateCurrentPassword:
+        return {
+          ...state,
+          currentPassword: {
+            ...state.currentPassword,
+            value: action.value,
+          },
+        };
+      case EditPasswordActionType.validateCurrentPassword: {
+        const { currentPassword } = state;
+        if (currentPassword.value.length === 0) {
+          currentPassword.error = true;
+          currentPassword.helperText =
+            'Current password is required. Please enter your current password.';
+        } else {
+          currentPassword.error = false;
+          currentPassword.helperText = '';
+        }
+        return {
+          ...state,
+          currentPassword,
+        };
+      }
+      case EditPasswordActionType.invalidateCurrentPassword:
+        return {
+          ...state,
+          currentPassword: {
+            ...state.currentPassword,
+            error: true,
+            helperText:
+              'Incorrect password. Please enter your current password again.',
+          },
+        };
+      case EditPasswordActionType.updateNewPassword:
+        return {
+          ...state,
+          newPassword: {
+            ...state.newPassword,
+            value: action.value,
+          },
+        };
+      case EditPasswordActionType.validateNewPassword: {
+        const { newPassword } = state;
+        if (
+          !/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/.test(newPassword.value)
+        ) {
+          newPassword.error = true;
+          newPassword.helperText =
+            'Please enter a new password with at least eight characters with at least one uppercase, one lowercase, and one digit.';
+        } else {
+          newPassword.error = false;
+          newPassword.helperText = '';
+        }
+        return {
+          ...state,
+          newPassword,
+        };
+      }
+      case EditPasswordActionType.updateNewPasswordConfirm:
+        return {
+          ...state,
+          newPasswordConfirm: {
+            ...state.newPasswordConfirm,
+            value: action.value,
+          },
+        };
+      case EditPasswordActionType.validateNewPasswordConfirm: {
+        const { newPassword, newPasswordConfirm } = state;
+        if (newPassword.value !== newPasswordConfirm.value) {
+          newPasswordConfirm.error = true;
+          newPasswordConfirm.helperText =
+            "Passwords don't match. Please reconfirm your new password.";
+        } else {
+          newPasswordConfirm.error = false;
+          newPasswordConfirm.helperText = '';
+        }
+        return {
+          ...state,
+          newPasswordConfirm,
+        };
+      }
+      case EditPasswordActionType.validateAll: {
+        let newState = editPasswordReducer(state, {
+          type: EditPasswordActionType.validateCurrentPassword,
+        });
+        newState = editPasswordReducer(newState, {
+          type: EditPasswordActionType.validateNewPassword,
+        });
+
+        return editPasswordReducer(newState, {
+          type: EditPasswordActionType.validateNewPasswordConfirm,
+        });
+      }
+      default:
+        return state;
+    }
+  };
+  const editPasswordInitial: EditPasswordState = {
+    currentPassword: {
+      value: '',
+      error: false,
+      helperText: '',
+    },
+    newPassword: {
+      value: '',
+      error: false,
+      helperText: '',
+    },
+    newPasswordConfirm: {
+      value: '',
+      error: false,
+      helperText: '',
+    },
+  };
+
+  const auth = useContext(AuthContext);
+  const notifications = useContext(NotificationsContext);
+  const router = useRouter();
+  const [editPasswordState, editPasswordDispatch] = useReducer(
+    editPasswordReducer,
+    editPasswordInitial,
+  );
+
+  useEffect(() => {
+    if (auth.state.isLoggedIn === false) {
+      router.replace('/account/sign-in');
+    }
+  }, [auth.state.isLoggedIn]);
+
+  const setCurrentPassword = (value: string) => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.updateCurrentPassword,
+      value,
+    });
+  };
+
+  const validateCurrentPassword = () => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.validateCurrentPassword,
+    });
+  };
+
+  const setNewPassword = (value: string) => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.updateNewPassword,
+      value,
+    });
+  };
+
+  const validateNewPassword = () => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.validateNewPassword,
+    });
+  };
+
+  const setNewPasswordConfirm = (value: string) => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.updateNewPasswordConfirm,
+      value,
+    });
+  };
+
+  const validateNewPasswordConfirm = () => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.validateNewPasswordConfirm,
+    });
+  };
+
+  const handleSubmit = async () => {
+    editPasswordDispatch({
+      type: EditPasswordActionType.validateAll,
+    });
+
+    if (
+      !editPasswordState.currentPassword.error &&
+      !editPasswordState.newPassword.error &&
+      !editPasswordState.newPasswordConfirm.error
+    ) {
+      try {
+        const response = await AccountAPI.putPassword(
+          editPasswordState.currentPassword.value,
+          editPasswordState.newPassword.value,
+          editPasswordState.newPasswordConfirm.value,
+        );
+        auth.dispatch({
+          type: AuthActions.UPDATE_USER,
+          payload: {
+            user: response.data.user,
+          },
+        });
+        notifications.dispatch({
+          type: NotificationsActionType.enqueue,
+          value: {
+            message: 'Password successfully changed.',
+            actions: {
+              close: true,
+            },
+            autoHideDuration: 5000,
+          },
+        });
+        router.push('/account/settings');
+      } catch (error) {
+        if (isAxiosError(error) && error?.response) {
+          switch (error.response.data.errorCode) {
+            case 1:
+            case 2:
+            case 3: {
+              editPasswordDispatch({
+                type: EditPasswordActionType.validateAll,
+              });
+              notifications.dispatch({
+                type: NotificationsActionType.enqueue,
+                value: {
+                  message: 'Cannot edit password.',
+                  actions: {
+                    close: true,
+                  },
+                  autoHideDuration: 5000,
+                },
+              });
+              break;
+            }
+            case 5: {
+              editPasswordDispatch({
+                type: EditPasswordActionType.invalidateCurrentPassword,
+              });
+              notifications.dispatch({
+                type: NotificationsActionType.enqueue,
+                value: {
+                  message: 'Cannot edit password.',
+                  actions: {
+                    close: true,
+                  },
+                  autoHideDuration: 5000,
+                },
+              });
+              break;
+            }
+            case 4:
+            default: {
+              notifications.dispatch({
+                type: NotificationsActionType.enqueue,
+                value: {
+                  message: 'Network Error. Cannot edit password.',
+                  actions: {
+                    label: {
+                      text: 'Retry',
+                      onClick: handleSubmit,
+                    },
+                  },
+                  autoHideDuration: 5000,
+                },
+              });
+              break;
+            }
+          }
+        } else {
+          notifications.dispatch({
+            type: NotificationsActionType.enqueue,
+            value: {
+              message: 'Internal Error. Cannot edit password.',
+              actions: {
+                label: {
+                  text: 'Retry',
+                  onClick: handleSubmit,
+                },
+              },
+              autoHideDuration: 5000,
+            },
+          });
+        }
+      }
+    } else {
+      notifications.dispatch({
+        type: NotificationsActionType.enqueue,
+        value: {
+          message: 'Cannot edit password.',
+          actions: {
+            close: true,
+          },
+          autoHideDuration: 5000,
+        },
+      });
+    }
+  };
+
+  return (
+    <SettingsMain id="edit-password">
+      <SettingsHead
+        id="edit-password-head"
+        headlineId="edit-password-headline"
+        back={{ name: 'Settings', href: '/account/settings' }}
+      >
+        Edit Password
+      </SettingsHead>
+      <SettingsPane id="edit-password-pane">
+        <SettingsSection className={styles['settings__section--leading']}>
+          <SettingsTextField
+            id="current-password"
+            label="Current Password"
+            type="password"
+            value={editPasswordState.currentPassword.value}
+            setValue={setCurrentPassword}
+            error={editPasswordState.currentPassword.error}
+            validate={validateCurrentPassword}
+            helperText={editPasswordState.currentPassword.helperText}
+            autoComplete="current-password"
+          />
+        </SettingsSection>
+        <SettingsSection>
+          <SettingsTextField
+            id="new-password"
+            label="New Password"
+            type="password"
+            value={editPasswordState.newPassword.value}
+            setValue={setNewPassword}
+            error={editPasswordState.newPassword.error}
+            validate={validateNewPassword}
+            helperText={editPasswordState.newPassword.helperText}
+            autoComplete="new-password"
+          />
+          <SettingsTextField
+            id="new-password-confirm"
+            label="Confirm New Password"
+            type="password"
+            value={editPasswordState.newPasswordConfirm.value}
+            setValue={setNewPasswordConfirm}
+            error={editPasswordState.newPasswordConfirm.error}
+            validate={validateNewPasswordConfirm}
+            helperText={editPasswordState.newPasswordConfirm.helperText}
+            autoComplete="new-password"
+          />
+        </SettingsSection>
+        <SettingsButton variant="filled" onClick={handleSubmit}>
+          Save
+        </SettingsButton>
+      </SettingsPane>
+    </SettingsMain>
+  );
+}
+
+export default EditPassword;

--- a/client/src/app/account/settings/password/styles/editPassword.module.scss
+++ b/client/src/app/account/settings/password/styles/editPassword.module.scss
@@ -1,0 +1,9 @@
+@use 'shape';
+
+.settings {
+  &__section {
+    &--leading {
+      margin-top: shape.$extra-large;
+    }
+  }
+}

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -27,6 +27,7 @@ export enum AuthActions {
   EDIT_USERNAME,
   VERIFY,
   EDIT_PROFILE_PICTURE,
+  UPDATE_USER,
 }
 
 type AuthAction =
@@ -52,6 +53,16 @@ type AuthAction =
     }
   | {
       type: AuthActions.EDIT_PROFILE_PICTURE;
+      payload: {
+        user: {
+          id: string;
+          username: string;
+          profilePic: string;
+        };
+      };
+    }
+  | {
+      type: AuthActions.UPDATE_USER;
       payload: {
         user: {
           id: string;
@@ -114,6 +125,11 @@ function authReducer(prev: IAuthState, action: AuthAction): IAuthState {
       return {
         ...prev,
         isLoggedIn: action.payload.isLoggedIn,
+        user: action.payload.user,
+      };
+    case AuthActions.UPDATE_USER:
+      return {
+        ...prev,
         user: action.payload.user,
       };
     default:

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -455,6 +455,7 @@ export const putPassword = async (request: Request, response: Response) => {
 
     const salt = await bcrypt.genSalt(10);
     user.password = await bcrypt.hash(newPassword, salt);
+    await user.save();
     return response.status(200).json({
       success: true,
       user: {

--- a/server/controllers/auth-controller.ts
+++ b/server/controllers/auth-controller.ts
@@ -396,6 +396,82 @@ export const putProfilePic = async (request: Request, response: Response) => {
   }
 };
 
+export const putPassword = async (request: Request, response: Response) => {
+  try {
+    const { currentPassword, newPassword, newPasswordConfirm } = request.body;
+    const { userId } = request as any;
+
+    let missingFields = 0;
+    if (!currentPassword) {
+      missingFields |= 1 << 2;
+    }
+    if (!newPassword) {
+      missingFields |= 1 << 1;
+    }
+    if (!newPasswordConfirm) {
+      missingFields |= 1 << 0;
+    }
+    if (missingFields) {
+      return response.status(400).json({
+        success: false,
+        errorCode: 1,
+        missingFields,
+        errorMessage: 'Please enter all fields.',
+      });
+    }
+
+    if (!/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/.test(newPassword)) {
+      return response.status(400).json({
+        success: false,
+        errorCode: 2,
+        errorMessage: 'Please enter a valid password.',
+      });
+    }
+
+    if (newPassword !== newPasswordConfirm) {
+      return response.status(400).json({
+        success: false,
+        errorCode: 3,
+        errorMessage: 'Please confirm the new password.',
+      });
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      return response.status(400).json({
+        success: false,
+        errorCode: 4,
+        errorMessage: 'The user is missing.',
+      });
+    }
+
+    if (!(await bcrypt.compare(currentPassword, user.password))) {
+      return response.status(401).json({
+        success: false,
+        errorCode: 5,
+        errorMessage: 'The current password is incorrect.',
+      });
+    }
+
+    const salt = await bcrypt.genSalt(10);
+    user.password = await bcrypt.hash(newPassword, salt);
+    return response.status(200).json({
+      success: true,
+      user: {
+        id: user._id,
+        username: user.username,
+        profilePic: Buffer.from(user.profilePic).toString('base64'),
+      },
+    });
+  } catch (error) {
+    return response.status(500).json({
+      success: false,
+      errorCode: 0,
+      errorMessage: 'There has been an internal error. Please try again later.',
+    });
+  }
+};
+
 export const logoutUser = async (req: Request, res: Response) => {
   try {
     // Clear the token cookie on the client side
@@ -440,7 +516,7 @@ export const getResetPasswordLink = async (req: Request, res: Response) => {
     user.resetPasswordToken = resetToken;
     user.resetPasswordExpires = new Date(Date.now() + 3600000); // 1 hour from now
 
-    const savedUser = await user.save();
+    await user.save();
 
     // Setup email transport
     let transporter = nodemailer.createTransport({

--- a/server/routes/auth-router.ts
+++ b/server/routes/auth-router.ts
@@ -14,7 +14,7 @@ router.post('/username', auth.verify, AuthController.postUsername);
 router.post('/login', AuthController.loginUser);
 router.post('/logout', AuthController.logoutUser);
 router.put('/profile-pic', auth.verify, AuthController.putProfilePic);
-// router.get('/loggedIn', AuthController.getLoggedIn)
+router.put('/password', auth.verify, AuthController.putPassword);
 
 router.post('/request-reset-password', AuthController.getResetPasswordLink);
 router.post('/reset-password/:token', AuthController.handlePasswordResetting);

--- a/server/tests/user.test.ts
+++ b/server/tests/user.test.ts
@@ -355,6 +355,102 @@ describe('POST /auth/username', () => {
   });
 });
 
+describe('PUT /auth/password', () => {
+  const mockUser = {
+    _id: '65677439126531bcfbbe2c10',
+    username: 'someUser',
+    email: 'someUser@gmail.com',
+    profilePic: Buffer.from('', 'base64'),
+    password: '********',
+    maps: [],
+    save: jest.fn().mockResolvedValue(this),
+  };
+
+  beforeEach(() => {
+    jest.mock('bcrypt');
+    jest.mock('../models/user-model');
+    jest.mock('../auth/index');
+    (auth.verify as jest.Mock).mockImplementation((request, response, next) => {
+      request.userId = '65677439126531bcfbbe2c10';
+      return next();
+    });
+    (userModel.findById as jest.Mock).mockResolvedValue(mockUser);
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('*********');
+  });
+
+  it('returns the user when successfully edited password.', async () => {
+    const response = await supertest(app).put('/auth/password').send({
+      currentPassword: '********',
+      newPassword: 'Passw0rd',
+      newPasswordConfirm: 'Passw0rd',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toStrictEqual({
+      success: true,
+      user: {
+        id: '65677439126531bcfbbe2c10',
+        username: 'someUser',
+        profilePic: '',
+      },
+    });
+  });
+
+  it('returns a bad request when some fields are missing.', async () => {
+    const response = await supertest(app).put('/auth/password').send({
+      currentPassword: '********',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errorCode).toBe(1);
+    expect(response.body.missingFields).toBe(0b011);
+  });
+
+  it('returns a bad request when the new password does not meet requirements.', async () => {
+    const response = await supertest(app).put('/auth/password').send({
+      currentPassword: '********',
+      newPassword: '********',
+      newPasswordConfirm: '********',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errorCode).toBe(2);
+  });
+
+  it('returns a bad request when the new password does not match its confirmation.', async () => {
+    const response = await supertest(app).put('/auth/password').send({
+      currentPassword: '********',
+      newPassword: 'Passw0rd',
+      newPasswordConfirm: 'Password',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errorCode).toBe(3);
+  });
+
+  it('returns an unauthorized request if the current password is incorrect.', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    const response = await supertest(app).put('/auth/password').send({
+      currentPassword: '********',
+      newPassword: 'Passw0rd',
+      newPasswordConfirm: 'Passw0rd',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errorCode).toBe(5);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});
+
 describe('PUT /auth/profile-picture', () => {
   const mockUser = {
     _id: '65677439126531bcfbbe2c10',
@@ -427,6 +523,10 @@ describe('PUT /auth/profile-picture', () => {
     expect(response.body).toHaveProperty('errorCode');
     expect(response.body.errorCode).toBe(2);
     expect(response.body).toHaveProperty('errorMessage');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 });
 
@@ -571,6 +671,7 @@ describe('GET /auth/reset-password/:token ', () => {
     console.log('Password resetted user', response.body.user);
     expect(response.body.user.resetPasswordToken).toEqual(undefined);
     expect(response.body.user.resetPasswordExpires).toEqual(undefined);
+    console.log(response.body.user);
     expect(response.body.user.password).not.toEqual('********');
   });
 });


### PR DESCRIPTION
The new `/account/settings/password` page allows the user to change their password.

### Features
- Created an `/account/settings/password` page, allowing the user to change their password by confirming their current password, and verifying their new password.
- The API `PUT /auth/endpoint` modifies the user document and expects the following body:
```
{
  currentPassword: string;
  newPassword: string;
  newPasswordConfirm: string;
}
```